### PR TITLE
Falta una inversión en el método de Laplace

### DIFF
--- a/09-calculo-bayes.Rmd
+++ b/09-calculo-bayes.Rmd
@@ -279,7 +279,7 @@ g(\theta)f(y\mid \theta)
 &= \exp\left(h(\theta)\right)\\
 &= \exp \left(h(\hat \theta) + \frac{1}{2}(\theta-\hat \theta)^\top h^{\prime\prime}(\hat \theta)(\theta-\hat \theta \right) \\
 &= \exp \left(h(\hat \theta)\right) \exp\left(\frac{1}{2}(\theta-\hat \theta)^\top h^{\prime\prime}(\hat \theta)(\theta-\hat \theta \right) \\
-&= \exp \left(h(\hat \theta)\right) \exp\left(-\frac{1}{2}(\theta-\hat \theta)^\top (-h^{\prime\prime}(\hat \theta))^{-1}(\theta-\hat \theta \right) \\
+&= \exp \left(h(\hat \theta)\right) \exp\left(-\frac{1}{2}(\theta-\hat \theta)^\top \left ( (-h^{\prime\prime}(\hat \theta))^{-1} \right )^{-1}(\theta-\hat \theta \right) \\
 \end{align*}
 
 


### PR DESCRIPTION
Al ver la matriz de covarianzas, hace falta considerar la inversa de la matriz